### PR TITLE
Raise `KeyError` when the dependency is not found in the container

### DIFF
--- a/knot.py
+++ b/knot.py
@@ -87,10 +87,10 @@ class Container(dict):
         """
         return self.provide(*args)
 
-    def provide(self, name, default=None):
+    def provide(self, name):
         """Gets the value registered with ``name`` and determines whether the
-        value is a provider or a configuration setting. The ``default`` value
-        is returned if ``name`` is unknown.
+        value is a provider or a configuration setting. The ``KeyError`` is
+        raised when the ``name`` is not found.
 
         The registered value is interpreted as a provider if it's callable. The
         provider is called with a single argument, the current
@@ -99,11 +99,9 @@ class Container(dict):
 
         :param name:
             The name of the provider or configuration setting.
-        :param default:
-            The default value to return if name is unknown.
         """
-        rv = super(Container, self).get(name)
-        return rv(self) if callable(rv) else rv or default
+        rv = self[name]
+        return rv(self) if callable(rv) else rv
 
     def add_factory(self, factory, name=None):
         """Registers a factory on the container. A factory is a provider with

--- a/test_knot.py
+++ b/test_knot.py
@@ -22,17 +22,17 @@ class TestContainer(unittest.TestCase):
 
         self.assertEqual(c.provide('value'), 'foobar')
 
-    def test_returns_default(self):
+    def test_raises_key_error_when_name_not_found(self):
         c = Container()
 
-        self.assertEqual(c.provide('foo', 'bar'), 'bar')
+        self.assertRaises(KeyError, lambda: c.provide('foo'))
 
     def test_forwards_to_provide(self):
         c = Container()
         c.provide = MagicMock()
 
-        c.provide('foo', 'bar', 'default')
-        c.provide.assert_called_with('foo', 'bar', 'default')
+        c.provide('foo')
+        c.provide.assert_called_with('foo')
 
     def test_caches_return_value_provider(self):
         c = Container()


### PR DESCRIPTION
Previously the `provide` method returned `None` if the dependency was not found. This could
potentially delay code errors in case one made a typo in the dependency path.
Now when the `KeyError` is raised, application will fail instantly.
